### PR TITLE
Compensate that HyperV nodes finish build before devstack

### DIFF
--- a/jobs/build_hyperv.sh
+++ b/jobs/build_hyperv.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+hyperv_node=$1
+# Loading all the needed functions
+source /usr/local/src/hyperv-compute-ci/jobs/library.sh
+
+# Loading parameters
+source /home/jenkins-slave/runs/devstack_params.$ZUUL_UUID.txt
+
+# building HyperV node
+echo $hyperv_node
+join_hyperv $hyperv_node $WIN_USER $WIN_PASS

--- a/jobs/run_initialize.sh
+++ b/jobs/run_initialize.sh
@@ -195,11 +195,11 @@ pid_devstack=$!
 
 # Building and joining HyperV nodes
 echo `date -u +%H:%M:%S` "Started building & joining Hyper-V node: $hyperv01"
-nohup /usr/local/src/hyperv-compute-ci/jobs/build_hv01.sh > /home/jenkins-slave/logs/hyperv-build-log-$ZUUL_UUID-$hyperv01 2>&1 &
+nohup /usr/local/src/hyperv-compute-ci/jobs/build_hyperv.sh $hyperv01 > /home/jenkins-slave/logs/hyperv-build-log-$ZUUL_UUID-$hyperv01 2>&1 &
 pid_hv01=$!
 
 echo `date -u +%H:%M:%S` "Started building & joining Hyper-V node: $hyperv02"
-nohup /usr/local/src/hyperv-compute-ci/jobs/build_hv02.sh > /home/jenkins-slave/logs/hyperv-build-log-$ZUUL_UUID-$hyperv02 2>&1 &
+nohup /usr/local/src/hyperv-compute-ci/jobs/build_hyperv.sh $hyperv02 > /home/jenkins-slave/logs/hyperv-build-log-$ZUUL_UUID-$hyperv02 2>&1 &
 pid_hv02=$!
 
 # Waiting for devstack threaded job to finish
@@ -213,7 +213,19 @@ cat /home/jenkins-slave/logs/hyperv-build-log-$ZUUL_UUID-$hyperv01
 wait $pid_hv02
 cat /home/jenkins-slave/logs/hyperv-build-log-$ZUUL_UUID-$hyperv02
 
+# Stopping HyperV services and cleaning up logs & starting them back - workaround because HyperV build finished before devstack
+run_wsmancmd_with_retry $hyperv01 $WIN_USER $WIN_PASS 'powershell Stop-Service nova-compute && Stop-Service neutron-hyperv-agent'
+run_wsmancmd_with_retry $hyperv01 $WIN_USER $WIN_PASS 'powershell Remove-Item -force C:\OpenStack\Log\*'
+run_wsmancmd_with_retry $hyperv02 $WIN_USER $WIN_PASS 'powershell Stop-Service nova-compute && Stop-Service neutron-hyperv-agent'
+run_wsmancmd_with_retry $hyperv02 $WIN_USER $WIN_PASS 'powershell Remove-Item -force C:\OpenStack\Log\*'
+run_wsmancmd_with_retry $hyperv01 $WIN_USER $WIN_PASS 'powershell Start-Service nova-compute && Start-Service neutron-hyperv-agent'
+run_wsmancmd_with_retry $hyperv02 $WIN_USER $WIN_PASS 'powershell Start-Service nova-compute && Start-Service neutron-hyperv-agent'
+
+echo "Allow 1 minute for services to connect to devstack.."
+sleep 60 
+
 #check for nova join (must equal 2)
+echo "Checking that both nodes are joined.."
 run_ssh_cmd_with_retry ubuntu@$FLOATING_IP $DEVSTACK_SSH_KEY 'source /home/ubuntu/keystonerc; NOVA_COUNT=$(nova service-list | grep nova-compute | grep -c -w up); if [ "$NOVA_COUNT" != 2 ];then nova service-list; exit 1;fi' 12
 run_ssh_cmd_with_retry ubuntu@$FLOATING_IP $DEVSTACK_SSH_KEY 'source /home/ubuntu/keystonerc; nova service-list' 1
 #check for neutron join (must equal 2)


### PR DESCRIPTION
- stop hyperv services and cleanup logs after they are build
- start hyperv services back after devstack finished
- improved nohup for hyperv
