### PR TITLE
Compensate that HyperV nodes finish build before devstack

### DIFF
--- a/devstack_vm/bin/collect_logs.sh
+++ b/devstack_vm/bin/collect_logs.sh
@@ -87,7 +87,7 @@ function archive_hyperv_configs() {
     do
         if [ -d "$HYPERV_CONFIGS/$i" ]
         then
-            NAME=`echo $i | sed 's/^\(hv-compute[0-9]\{2,3\}\)\|^\(c[0-9]-r[0-9]-u[0-9]\{2\}\)/hv-compute'$COUNT'/g'`
+            NAME=`echo $i | sed 's/^\(hv-compute[0-9]\{2,3\}\)\|^\(c[0-9]-r[0-9]\{2\}\-u[0-9]\{2\}\)/hv-compute'$COUNT'/g'`
             
             mkdir -p "$CONFIG_DST_HV/$NAME"
             COUNT=$(($COUNT + 1))
@@ -126,7 +126,7 @@ function archive_hyperv_logs() {
     do
         if [ -d "$HYPERV_LOGS/$i" ]
         then
-            NAME=`echo $i | sed 's/^\(hv-compute[0-9]\{2,3\}\)\|^\(c[0-9]-r[0-9]-u[0-9]\{2\}\)/hv-compute'$COUNT'/g'`
+            NAME=`echo $i | sed 's/^\(hv-compute[0-9]\{2,3\}\)\|^\(c[0-9]-r[0-9]\{2\}\-u[0-9]\{2\}\)/hv-compute'$COUNT'/g'`
             
             mkdir -p "$LOG_DST_HV/$NAME"
             COUNT=$(($COUNT + 1))

--- a/jobs/build_hyperv.sh
+++ b/jobs/build_hyperv.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+hyperv_node=$1
+# Loading all the needed functions
+source /usr/local/src/hyperv-compute-ci/jobs/library.sh
+
+# Loading parameters
+source /home/jenkins-slave/runs/devstack_params.$ZUUL_UUID.txt
+
+# building HyperV node
+echo $hyperv_node
+join_hyperv $hyperv_node $WIN_USER $WIN_PASS

--- a/jobs/run_collect_and_cleanup.sh
+++ b/jobs/run_collect_and_cleanup.sh
@@ -65,14 +65,20 @@ if [ "$IS_DEBUG_JOB" != "yes" ]
 
 		echo "Extracting logs"
 		ssh -o "UserKnownHostsFile /dev/null" -o "StrictHostKeyChecking no" -i $LOGS_SSH_KEY logs@logs.openstack.tld "tar -xzf /srv/logs/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/aggregate-logs.tar.gz -C /srv/logs/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/"
-    
+
+                echo "Uploading temporary logs"
+                scp -o "UserKnownHostsFile /dev/null" -o "StrictHostKeyChecking no" -i $LOGS_SSH_KEY "/home/jenkins-slave/logs/hyperv-build-log-$ZUUL_UUID-*" logs@logs.openstack.tld:/srv/logs/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/
+                scp -o "UserKnownHostsFile /dev/null" -o "StrictHostKeyChecking no" -i $LOGS_SSH_KEY "/home/jenkins-slave/logs/devstack-build-log-$ZUUL_UUID" logs@logs.openstack.tld:/srv/logs/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/
+
 		echo "Fixing permissions on all log files"
 		ssh -o "UserKnownHostsFile /dev/null" -o "StrictHostKeyChecking no" -i $LOGS_SSH_KEY logs@logs.openstack.tld "chmod a+rx -R /srv/logs/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET"
+
 		echo "Removing HyperV temporary console logs.."
 		rm -fv /home/jenkins-slave/logs/hyperv-build-log-$ZUUL_UUID-$hyperv01
 		rm -fv /home/jenkins-slave/logs/hyperv-build-log-$ZUUL_UUID-$hyperv02
 		echo "Removing temporary devstack log.."
 		rm -fv /home/jenkins-slave/logs/devstack-build-log-$ZUUL_UUID
+
 		echo "Releasing devstack floating IP"
 		nova remove-floating-ip "$NAME" "$FLOATING_IP"
 		echo "Removing devstack VM"
@@ -83,22 +89,33 @@ if [ "$IS_DEBUG_JOB" != "yes" ]
 		rm -f /home/jenkins-slave/runs/devstack_params.$ZUUL_UUID.txt
 	else
 		TIMESTAMP=$(date +%d-%m-%Y_%H-%M)
-        echo "Creating logs destination folder"
-        ssh -o "UserKnownHostsFile /dev/null" -o "StrictHostKeyChecking no" -i $LOGS_SSH_KEY logs@logs.openstack.tld "if [ -z '$ZUUL_CHANGE' ] || [ -z '$ZUUL_PATCHSET' ]; then echo 'Missing parameters!'; exit 1; elif [ ! -d /srv/logs/debug/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/$TIMESTAMP ]; then mkdir -p /srv/logs/debug/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/$TIMESTAMP; else rm -rf /srv/logs/debug/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/$TIMESTAMP/*; fi"
+        	echo "Creating logs destination folder"
+        	ssh -o "UserKnownHostsFile /dev/null" -o "StrictHostKeyChecking no" -i $LOGS_SSH_KEY logs@logs.openstack.tld "if [ -z '$ZUUL_CHANGE' ] || [ -z '$ZUUL_PATCHSET' ]; then echo 'Missing parameters!'; exit 1; elif [ ! -d /srv/logs/debug/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/$TIMESTAMP ]; then mkdir -p /srv/logs/debug/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/$TIMESTAMP; else rm -rf /srv/logs/debug/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/$TIMESTAMP/*; fi"
 
 		echo "Downloading logs"
-        scp -o "UserKnownHostsFile /dev/null" -o "StrictHostKeyChecking no" -i $DEVSTACK_SSH_KEY ubuntu@$FLOATING_IP:/home/ubuntu/aggregate.tar.gz "aggregate-$NAME.tar.gz"
+        	scp -o "UserKnownHostsFile /dev/null" -o "StrictHostKeyChecking no" -i $DEVSTACK_SSH_KEY ubuntu@$FLOATING_IP:/home/ubuntu/aggregate.tar.gz "aggregate-$NAME.tar.gz"
 
 		echo "Uploading logs"
-        scp -o "UserKnownHostsFile /dev/null" -o "StrictHostKeyChecking no" -i $LOGS_SSH_KEY "aggregate-$NAME.tar.gz" logs@logs.openstack.tld:/srv/logs/debug/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/$TIMESTAMP/aggregate-logs.tar.gz
-        gzip -9 /home/jenkins-slave/logs/console-$NAME.log
-        scp -o "UserKnownHostsFile /dev/null" -o "StrictHostKeyChecking no" -i $LOGS_SSH_KEY "/home/jenkins-slave/logs/console-$NAME.log.gz" logs@logs.openstack.tld:/srv/logs/debug/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/$TIMESTAMP/console.log.gz && rm -f /home/jenkins-slave/logs/console-$NAME.log.gz
+        	scp -o "UserKnownHostsFile /dev/null" -o "StrictHostKeyChecking no" -i $LOGS_SSH_KEY "aggregate-$NAME.tar.gz" logs@logs.openstack.tld:/srv/logs/debug/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/$TIMESTAMP/aggregate-logs.tar.gz
+        	gzip -9 /home/jenkins-slave/logs/console-$NAME.log
+        	scp -o "UserKnownHostsFile /dev/null" -o "StrictHostKeyChecking no" -i $LOGS_SSH_KEY "/home/jenkins-slave/logs/console-$NAME.log.gz" logs@logs.openstack.tld:/srv/logs/debug/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/$TIMESTAMP/console.log.gz && rm -f /home/jenkins-slave/logs/console-$NAME.log.gz
 
 		echo "Extracting logs"
-        ssh -o "UserKnownHostsFile /dev/null" -o "StrictHostKeyChecking no" -i $LOGS_SSH_KEY logs@logs.openstack.tld "tar -xzf /srv/logs/debug/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/$TIMESTAMP/aggregate-logs.tar.gz -C /srv/logs/debug/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/$TIMESTAMP/"
+        	ssh -o "UserKnownHostsFile /dev/null" -o "StrictHostKeyChecking no" -i $LOGS_SSH_KEY logs@logs.openstack.tld "tar -xzf /srv/logs/debug/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/$TIMESTAMP/aggregate-logs.tar.gz -C /srv/logs/debug/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/$TIMESTAMP/"
+
+                echo "Uploading temporary logs"
+                scp -o "UserKnownHostsFile /dev/null" -o "StrictHostKeyChecking no" -i $LOGS_SSH_KEY "/home/jenkins-slave/logs/hyperv-build-log-$ZUUL_UUID-*" logs@logs.openstack.tld:/srv/logs/debug/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/$TIMESTAMP/
+                scp -o "UserKnownHostsFile /dev/null" -o "StrictHostKeyChecking no" -i $LOGS_SSH_KEY "/home/jenkins-slave/logs/devstack-build-log-$ZUUL_UUID" logs@logs.openstack.tld:/srv/logs/debug/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/$TIMESTAMP/
 
 		echo "Fixing permissions on all log files"
-        ssh -o "UserKnownHostsFile /dev/null" -o "StrictHostKeyChecking no" -i $LOGS_SSH_KEY logs@logs.openstack.tld "chmod a+rx -R /srv/logs/debug/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/$TIMESTAMP"    
+        	ssh -o "UserKnownHostsFile /dev/null" -o "StrictHostKeyChecking no" -i $LOGS_SSH_KEY logs@logs.openstack.tld "chmod a+rx -R /srv/logs/debug/compute-hyperv/$ZUUL_CHANGE/$ZUUL_PATCHSET/$TIMESTAMP"
+
+                echo "Removing HyperV temporary console logs.."
+                rm -fv /home/jenkins-slave/logs/hyperv-build-log-$ZUUL_UUID-$hyperv01
+                rm -fv /home/jenkins-slave/logs/hyperv-build-log-$ZUUL_UUID-$hyperv02
+                echo "Removing temporary devstack log.."
+                rm -fv /home/jenkins-slave/logs/devstack-build-log-$ZUUL_UUID
+
 fi
 
 set -e

--- a/jobs/run_initialize.sh
+++ b/jobs/run_initialize.sh
@@ -195,11 +195,11 @@ pid_devstack=$!
 
 # Building and joining HyperV nodes
 echo `date -u +%H:%M:%S` "Started building & joining Hyper-V node: $hyperv01"
-nohup /usr/local/src/hyperv-compute-ci/jobs/build_hv01.sh > /home/jenkins-slave/logs/hyperv-build-log-$ZUUL_UUID-$hyperv01 2>&1 &
+nohup /usr/local/src/hyperv-compute-ci/jobs/build_hyperv.sh $hyperv01 > /home/jenkins-slave/logs/hyperv-build-log-$ZUUL_UUID-$hyperv01 2>&1 &
 pid_hv01=$!
 
 echo `date -u +%H:%M:%S` "Started building & joining Hyper-V node: $hyperv02"
-nohup /usr/local/src/hyperv-compute-ci/jobs/build_hv02.sh > /home/jenkins-slave/logs/hyperv-build-log-$ZUUL_UUID-$hyperv02 2>&1 &
+nohup /usr/local/src/hyperv-compute-ci/jobs/build_hyperv.sh $hyperv02 > /home/jenkins-slave/logs/hyperv-build-log-$ZUUL_UUID-$hyperv02 2>&1 &
 pid_hv02=$!
 
 # Waiting for devstack threaded job to finish
@@ -213,7 +213,19 @@ cat /home/jenkins-slave/logs/hyperv-build-log-$ZUUL_UUID-$hyperv01
 wait $pid_hv02
 cat /home/jenkins-slave/logs/hyperv-build-log-$ZUUL_UUID-$hyperv02
 
+# Stopping HyperV services and cleaning up logs & starting them back - workaround because HyperV build finished before devstack
+run_wsmancmd_with_retry $hyperv01 $WIN_USER $WIN_PASS 'powershell Stop-Service nova-compute && powershell Stop-Service neutron-hyperv-agent'
+run_wsmancmd_with_retry $hyperv01 $WIN_USER $WIN_PASS 'powershell Remove-Item -force C:\OpenStack\Log\*'
+run_wsmancmd_with_retry $hyperv02 $WIN_USER $WIN_PASS 'powershell Stop-Service nova-compute && powershell Stop-Service neutron-hyperv-agent'
+run_wsmancmd_with_retry $hyperv02 $WIN_USER $WIN_PASS 'powershell Remove-Item -force C:\OpenStack\Log\*'
+run_wsmancmd_with_retry $hyperv01 $WIN_USER $WIN_PASS 'powershell Start-Service nova-compute && powershell Start-Service neutron-hyperv-agent'
+run_wsmancmd_with_retry $hyperv02 $WIN_USER $WIN_PASS 'powershell Start-Service nova-compute && powershell Start-Service neutron-hyperv-agent'
+
+echo "Allow 1 minute for services to connect to devstack.."
+sleep 60 
+
 #check for nova join (must equal 2)
+echo "Checking that both nodes are joined.."
 run_ssh_cmd_with_retry ubuntu@$FLOATING_IP $DEVSTACK_SSH_KEY 'source /home/ubuntu/keystonerc; NOVA_COUNT=$(nova service-list | grep nova-compute | grep -c -w up); if [ "$NOVA_COUNT" != 2 ];then nova service-list; exit 1;fi' 12
 run_ssh_cmd_with_retry ubuntu@$FLOATING_IP $DEVSTACK_SSH_KEY 'source /home/ubuntu/keystonerc; nova service-list' 1
 #check for neutron join (must equal 2)


### PR DESCRIPTION
- stop hyperv services and cleanup logs after they are build
- start hyperv services back after devstack finished
- improved nohup for hyperv
- fixed incomplete path when using debug job
- cleanup temporary logs
