### PR TITLE
Fix compute-hyperv driver import

### DIFF
--- a/HyperV/scripts/create-environment.ps1
+++ b/HyperV/scripts/create-environment.ps1
@@ -260,10 +260,10 @@ ExecRetry {
     }
     pushd $buildDir\compute-hyperv
     if (!$branchName.CompareTo('master')){
-        git fetch https://git.openstack.org/openstack/compute-hyperv refs/changes/99/310899/9
+        git fetch https://git.openstack.org/openstack/compute-hyperv refs/changes/99/310899/10
         cherry_pick FETCH_HEAD
     }
-    & pip install $buildDir\compute-hyperv    
+    & pip install -e $buildDir\compute-hyperv
     if ($LastExitCode) { Throw "Failed to install Hyperv-Compute fom repo" }
     popd
 }


### PR DESCRIPTION
This change updates the compute-hyperv fix to be cherry-picked.

Also, in order to properly load the compute-hyperv, we'll have
to temporarily install this package in developer mode.
